### PR TITLE
Typo fix

### DIFF
--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -25,7 +25,7 @@ The following sections explain a theoretical model. Modern JavaScript engines im
 
 ### Stack
 
-Function calls form a stack of _frames_.
+Function calls from a stack of _frames_.
 
 ```js
 function foo(b) {


### PR DESCRIPTION
It said 'form' where it should have said 'from in the first sentence describing the stack.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
